### PR TITLE
Fix namespace for Gradle 8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,6 +26,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.gainsight.px.mobile.flutter'
     compileSdkVersion 31
 
     defaultConfig {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.gainsight.px.mobile.flutter">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
Removed `package` from Manifest file andd specify `namespace` in `build.gradle`